### PR TITLE
Fix pebble service name

### DIFF
--- a/0.26.0/rockcraft.yaml
+++ b/0.26.0/rockcraft.yaml
@@ -5,8 +5,8 @@ version: "0.26.0"
 base: ubuntu@24.04
 license: Apache-2.0
 services:
-  blackbox-exporter:
-    command: /bin/blackbox_exporter --config.file=/etc/blackbox_exporter/config.yaml
+  blackbox:
+    command: /bin/blackbox_exporter --config.file=/etc/blackbox_exporter/config.yml
     override: replace
     startup: enabled
 platforms:
@@ -33,9 +33,9 @@ parts:
     plugin: dump
     source: .
     organize:
-      config.yaml: etc/blackbox_exporter/config.yaml
+      config.yaml: etc/blackbox_exporter/config.yml
     stage:
-      - etc/blackbox_exporter/config.yaml
+      - etc/blackbox_exporter/config.yml
   ca-certs:
     plugin: nil
     overlay-packages: [ca-certificates]


### PR DESCRIPTION
## Issue
The rock currently uses `blackbox-exporter` as the pebble service name, while the charm is using [`blackbox`](https://github.com/canonical/blackbox-exporter-k8s-operator/blob/main/src/blackbox.py#L40). So, when the charm starts, instead of replacing the rock's pebble service, it adds a new one that fails to start because the address is already in bind by the existing rock's service.


## Solution
Match the pebble service name of the rock with what the charm is expecting.

## Testing Instructions
Run itests of the blackbox exporter charm with this rock image.

## Drive-bys
- change `config.yaml` to `config.yml` 

