### PR TITLE
chore: add rock for 0.28.0

### DIFF
--- a/0.28.0/config.yaml
+++ b/0.28.0/config.yaml
@@ -1,0 +1,62 @@
+modules:
+  http_2xx:
+    prober: http
+    http:
+      preferred_ip_protocol: "ip4"
+  http_post_2xx:
+    prober: http
+    http:
+      method: POST
+  tcp_connect:
+    prober: tcp
+  pop3s_banner:
+    prober: tcp
+    tcp:
+      query_response:
+      - expect: "^+OK"
+      tls: true
+      tls_config:
+        insecure_skip_verify: false
+  grpc:
+    prober: grpc
+    grpc:
+      tls: true
+      preferred_ip_protocol: "ip4"
+  grpc_plain:
+    prober: grpc
+    grpc:
+      tls: false
+      service: "service1"
+  ssh_banner:
+    prober: tcp
+    tcp:
+      query_response:
+      - expect: "^SSH-2.0-"
+      - send: "SSH-2.0-blackbox-ssh-check"
+  ssh_banner_extract:
+    prober: tcp
+    timeout: 5s
+    tcp:
+      query_response:
+      - expect: "^SSH-2.0-([^ -]+)(?: (.*))?$"
+        labels:
+        - name: ssh_version
+          value: "${1}"
+        - name: ssh_comments
+          value: "${2}"
+  irc_banner:
+    prober: tcp
+    tcp:
+      query_response:
+      - send: "NICK prober"
+      - send: "USER prober prober prober :prober"
+      - expect: "PING :([^ ]+)"
+        send: "PONG ${1}"
+      - expect: "^:[^ ]+ 001"
+  icmp:
+    prober: icmp
+  icmp_ttl5:
+    prober: icmp
+    timeout: 5s
+    icmp:
+      ttl: 5

--- a/0.28.0/rockcraft.yaml
+++ b/0.28.0/rockcraft.yaml
@@ -1,0 +1,50 @@
+name: blackbox-exporter
+summary: Blackbox Exporter in a Rock.
+description: "The blackbox exporter allows blackbox probing of endpoints over HTTP, HTTPS, DNS, TCP, ICMP and gRPC."
+version: "0.28.0"
+base: ubuntu@24.04
+license: Apache-2.0
+services:
+  blackbox:
+    command: /bin/blackbox_exporter --config.file=/etc/blackbox_exporter/config.yml
+    override: replace
+    startup: enabled
+platforms:
+  amd64:
+parts:
+  blackbox-exporter:
+    plugin: go
+    source: https://github.com/prometheus/blackbox_exporter
+    source-type: git
+    source-tag: "v0.28.0"
+    source-depth: 1
+    build-snaps:
+      - go/1.23/stable
+    build-environment:
+      - BUILD_IN_CONTAINER: "false"
+    build-packages:
+      - libsystemd-dev
+    override-build: |
+      make build
+      install -D -m755 blackbox_exporter $CRAFT_PART_INSTALL/bin/blackbox_exporter
+    stage:
+      - bin/blackbox_exporter
+  default-config:
+    plugin: dump
+    source: .
+    organize:
+      config.yaml: etc/blackbox_exporter/config.yml
+    stage:
+      - etc/blackbox_exporter/config.yml
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - blackbox-exporter
+      - ca-certs
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Adding rock for upstream version 0.28.0 because it contains a fix (found in PR #[1441](https://github.com/prometheus/blackbox_exporter/pull/1441) upstream) needed in our K8s charm.

## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
