### PR TITLE
fix: use build snap go/1.25/stable to avoid CVEs

### DIFF
--- a/0.28.0/rockcraft.yaml
+++ b/0.28.0/rockcraft.yaml
@@ -19,7 +19,7 @@ parts:
     source-tag: "v0.28.0"
     source-depth: 1
     build-snaps:
-      - go/1.23/stable
+      - go/1.25/stable
     build-environment:
       - BUILD_IN_CONTAINER: "false"
     build-packages:


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Our rock for version `0.28.0` has 4 CVEs in the Go standard lib because it was built using the 1.23 Go snap. Those 4 CVEs have been all been fixed by 1.25.5. 
The CVEs are:
1. CVE-2025-22874 fixed in 1.24.4
2. CVE-2025-47907 fixed in 1.24.6
3. CVE-2025-58183 fixed in 1.25.2
4. CVE-2025-61729 fixed in 1.25.5
## Solution
<!-- A summary of the solution addressing the above issue -->
The current `go/1.25/stable` is version 1.25.5, so building using it should make the CVEs go away. We now build using that.
```
snap info go
...
...
...
1.25/stable:         1.25.5       2025-12-10 (11017)
```

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
