### PR TITLE
chore: bump base to ubuntu@26.04

### DIFF
--- a/0.28.0/rockcraft.yaml
+++ b/0.28.0/rockcraft.yaml
@@ -2,7 +2,7 @@ name: blackbox-exporter
 summary: Blackbox Exporter in a Rock.
 description: "The blackbox exporter allows blackbox probing of endpoints over HTTP, HTTPS, DNS, TCP, ICMP and gRPC."
 version: "0.28.0"
-base: ubuntu@24.04
+base: ubuntu@26.04
 license: Apache-2.0
 services:
   blackbox:

--- a/0.28.0/rockcraft.yaml
+++ b/0.28.0/rockcraft.yaml
@@ -26,9 +26,9 @@ parts:
       - libsystemd-dev
     override-build: |
       make build
-      install -D -m755 blackbox_exporter $CRAFT_PART_INSTALL/bin/blackbox_exporter
+      install -D -m755 blackbox_exporter $CRAFT_PART_INSTALL/usr/bin/blackbox_exporter
     stage:
-      - bin/blackbox_exporter
+      - usr/bin/blackbox_exporter
   default-config:
     plugin: dump
     source: .

--- a/rocks.just
+++ b/rocks.just
@@ -169,7 +169,11 @@ release-oci-factory version=latest_version support="minor" risk="stable":
   if [ ! -e {{version}}/*.rock ]; then echo "× Error: rock not found. Please run 'just pack {{version}}' first."; exit 2; fi
   repository="$(git remote get-url origin | sed -E 's#(git@[^:]+:|https?://[^/]+/)##; s/\.git$//')"
   # Extract the base from the rockcraft.yaml (e.g. "ubuntu@24.04" -> "24.04")
+  # For bare-based rocks, fall back to build-base (e.g. "ubuntu@26.04" -> "26.04")
   rock_base="$(yq -r '.base' "{{version}}/rockcraft.yaml" | sed 's/.*@//')"
+  if [[ "$rock_base" == "bare" ]]; then
+    rock_base="$(yq -r '.["build-base"]' "{{version}}/rockcraft.yaml" | sed 's/.*@//')"
+  fi
   echo "Detected base: $rock_base"
   # Clone the oci-factory and push data to it
   gh repo sync --force observability-noctua-bot/oci-factory

--- a/spread.yaml
+++ b/spread.yaml
@@ -25,9 +25,7 @@ suites:
       sudo snap install --classic rockcraft
 
       # Wait for docker daemon to come online
-      sudo apt install --yes retry
-      retry --times=10 --delay 2 -- docker run hello-world
-      sudo apt remove --yes retry
+      for i in $(seq 1 10); do docker info >/dev/null 2>&1 && break || sleep 2; done
 
       # Load the rock into docker
       sudo rockcraft.skopeo --insecure-policy copy "oci-archive:$CRAFT_ARTIFACT" docker-daemon:rockcraft-test:latest


### PR DESCRIPTION
Bump `base` from `ubuntu@24.04` to `ubuntu@26.04` for version 0.28.0.